### PR TITLE
fix: correct calculation of lane offsets in rhopi

### DIFF
--- a/lib/src/permutations/rhoPi.nr
+++ b/lib/src/permutations/rhoPi.nr
@@ -8,7 +8,7 @@ fn rhoPi(state: [u64; constants::NUM_LANES]) -> [u64; constants::NUM_LANES] {
     // These are precomputed pairs of indices within the state array which specify how to perform the pi mapping.
     // Lanes are remapped such that the lane sitting at index READ_LANE_OFFSETS[i] is remapped to WRITE_LANE_OFFSETS[i].
     let READ_LANE_OFFSETS: [comptime Field; 24] = [1, 10, 7, 11, 17, 18, 3, 5, 16, 8, 21, 24, 4, 15, 23, 19, 13, 12, 2, 20, 14, 22, 9, 6];
-    let WRITE_LANE_OFFSETS: [comptime Field; 24] = [6, 1, 10, 7, 11, 17, 18, 3, 5, 16, 8, 21, 24, 4, 15, 23, 19, 13, 12, 2, 20, 14, 22, 9];
+    let WRITE_LANE_OFFSETS: [comptime Field; 24] = [10, 7, 11, 17, 18, 3, 5, 16, 8, 21, 24, 4, 15, 23, 19, 13, 12, 2, 20, 14, 22, 9, 6, 1];
 
     // This array defines the rho mapping to be applied to each lane.
     // Each lane is rotated by the specified number of bits, mapping the z coordinate as `z -> (z - T[i]) % LANE_LENGTH`

--- a/scripts/rhopi.ts
+++ b/scripts/rhopi.ts
@@ -19,6 +19,9 @@ const calculateXYPairs = () => {
   return pairs;
 };
 
+
+// NOTE: This calculation of the lanes remapping is incorrect.
+
 // Given the x and y coordinates of a lane, return the x and y coordinates of the lane it is mapped to by pi.
 const piLaneRemapping = (x: number, y: number): [number, number] => [(x + 3 * y) % 5, x];
 


### PR DESCRIPTION
It looks like we were calculating the pairings between lanes incorrectly for the pi permutation. We were performing the mapping backwards which shifted the array the wrong way which has now been fixed.

As we don't make use of a single uint64 as scratch space like many other implementations we could remove one of the offset arrays and write to the lanes in order. These array accesses _should_ be removed entirely by the compiler when it unrolls the for loop so I don't see a huge benefit